### PR TITLE
Fix roleIds IndexOutOfRangeException

### DIFF
--- a/GameServer/Models/FormationModel.cs
+++ b/GameServer/Models/FormationModel.cs
@@ -10,7 +10,7 @@ internal class FormationModel
 
     public void Set(int[] roleIds)
     {
-        for (int i = 0; i < RoleIds.Length; i++)
+        for (int i = 0; i < roleIds.Length; i++)
         {
             RoleIds[i] = roleIds[i];
         }


### PR DESCRIPTION
When selecting teams in such a way, like team1 -> team2 -> team1 -> team2, it will result in a System.IndexOutOfRangeException.
